### PR TITLE
BuildSourceBL: Use 96boards-hikey fork: uefi-tools

### DIFF
--- a/Reference-Platform/RPOfficial/ConsumerEdition/HiKey/BuildSourceBL.md
+++ b/Reference-Platform/RPOfficial/ConsumerEdition/HiKey/BuildSourceBL.md
@@ -34,7 +34,7 @@ git clone -b hikey-aosp https://github.com/96boards-hikey/OpenPlatformPkg.git
 git clone https://github.com/OP-TEE/optee_os.git
 git clone -b hikey https://github.com/96boards-hikey/arm-trusted-firmware.git
 git clone https://github.com/96boards-hikey/l-loader.git
-git clone git://git.linaro.org/uefi/uefi-tools.git
+git clone -b hikey-aosp https://github.com/96boards-hikey/uefi-tools.git
 ```
 
 #### Building EDK2/UEFI for HiKey


### PR DESCRIPTION
hikey-aosp branch

git.linaro.org/uefi/uefi-tools.git recently added support for gcc5
but github.com/96boards-hikey/edk2.git has not, so the build will
break if using a gcc5 version toolchain.

Fixes
http://www.96boards.org/forums/topic/cannot-build-hikey-fw-from-source
until hikey edk2 gets upstreamed.

Signed-off-by: Victor Chong victor.chong@linaro.org
