### PR TITLE
OE.md: fix the manifest branch

### DIFF
--- a/Reference-Platform/CECommon/OE.md
+++ b/Reference-Platform/CECommon/OE.md
@@ -86,7 +86,7 @@ To manage the various git trees and the OpenEmbedded environment, a repo manifes
 To initialize your build environment, you need to run:
 
     mkdir oe-rpb && cd oe-rpb
-    repo init -u https://github.com/96boards/oe-rpb-manifest.git -b jethro
+    repo init -u https://github.com/96boards/oe-rpb-manifest.git -b krogoth
     repo sync
     source setup-environment [<build folder>]
 


### PR DESCRIPTION
RPB had moved from jethro to krogoth quite some time ago. Having "jethro"
in the instructions causes confusion.

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>