### PR TITLE
Redirect ReleaseNotes.md to README.md

### DIFF
--- a/Reference-Platform/Platforms/Enterprise/ReleaseNotes.md
+++ b/Reference-Platform/Platforms/Enterprise/ReleaseNotes.md
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=README.md" />


### PR DESCRIPTION
There are still incoming links to ReleaseNotes.md that are now 404

Signed-off-by: Dan Rue <dan.rue@linaro.org>