### PR TITLE
README.md: drop suggestions release includes firmware

### DIFF
--- a/Reference-Platform/Platforms/Enterprise/README.md
+++ b/Reference-Platform/Platforms/Enterprise/README.md
@@ -1,6 +1,6 @@
 # Enterprise Reference Platform
 
-The enterprise reference platform is targeted to accelerate the high powered ARMv8 servers in both datacenter and cloud vertical markets. A unified Linux kernel are provided for all the supported platforms, verified against Industry standard firmware (SBBR and SBSA), simplifying software maintenance and deployment. The high level components such as Openstack, Ceph, Hadoop, and KVM are rigorously validated for each distribution. The enterprise software stack is based on Debian. The goal is to help bridge the gap between older technology present in today’s distributions and the latest ARM server optimizations. For more information and support please visit the [ERP forum](https://discuss.linaro.org/c/erp).
+The enterprise reference platform is targeted to accelerate the high powered ARMv8 servers in both datacenter and cloud vertical markets. A unified Linux kernel is provided for all the supported platforms, verified against Industry standard firmware (SBBR and SBSA), simplifying software maintenance and deployment. The high level components such as Openstack, Ceph, Hadoop, and KVM are rigorously validated for each distribution. The enterprise software stack is based on Debian. The goal is to help bridge the gap between older technology present in today’s distributions and the latest ARM server optimizations. For more information and support please visit the [ERP forum](https://discuss.linaro.org/c/erp).
 
 **Features:**
 

--- a/Reference-Platform/Platforms/Enterprise/README.md
+++ b/Reference-Platform/Platforms/Enterprise/README.md
@@ -1,11 +1,11 @@
 # Enterprise Reference Platform
 
-The enterprise reference platform is targeted to accelerate the high powered ARMv8 servers in both datacenter and cloud vertical markets. Industry standard firmware (SBBR and SBSA) and a unified Linux kernel are provided for all the supported platforms, simplifying software maintenance and deployment. The high level components such as Openstack, Ceph, Hadoop, and KVM are rigorously validated for each distribution. The enterprise software stack is based on Debian. The goal is to help bridge the gap between older technology present in today’s distributions and the latest ARM server optimizations. For more information and support please visit the [ERP forum](https://discuss.linaro.org/c/erp).
+The enterprise reference platform is targeted to accelerate the high powered ARMv8 servers in both datacenter and cloud vertical markets. A unified Linux kernel are provided for all the supported platforms, verified against Industry standard firmware (SBBR and SBSA), simplifying software maintenance and deployment. The high level components such as Openstack, Ceph, Hadoop, and KVM are rigorously validated for each distribution. The enterprise software stack is based on Debian. The goal is to help bridge the gap between older technology present in today’s distributions and the latest ARM server optimizations. For more information and support please visit the [ERP forum](https://discuss.linaro.org/c/erp).
 
 **Features:**
 
 - Unified Linux Kernel
-- Open Boot Firmware
+- Verified against existing Boot Firmware
    - Compliant with ARM SBSA and SBBR specifications
 - Debian Network Installer
 - Openstack and Ceph Reference Deployments


### PR DESCRIPTION
The last time system firmware was included as part of an ERP release was 16.12.
Firmware releases are now staggered (17.04, 17.10).
So reword to clarify that the ERP releases are validated against existing firmware.